### PR TITLE
Remove SwiftLintPlugin, Update headers for tracing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,6 @@ import Foundation
 import PackageDescription
 
 var targetPlugins: [Target.PluginUsage] = [.plugin(name: "SwiftLintPlugin", package: "SwiftLint")]
-
 // Work around for plugin dependency being included in iOS target when using `xcodebuild test`
 // (See bin/xctest)
 // https://forums.swift.org/t/xcode-attempts-to-build-plugins-for-ios-is-there-a-workaround/57029

--- a/Package.swift
+++ b/Package.swift
@@ -5,13 +5,20 @@ import Foundation
 import PackageDescription
 
 var targetPlugins: [Target.PluginUsage] = [.plugin(name: "SwiftLintPlugin", package: "SwiftLint")]
+
 // Work around for plugin dependency being included in iOS target when using `xcodebuild test`
 // (See bin/xctest)
 // https://forums.swift.org/t/xcode-attempts-to-build-plugins-for-ios-is-there-a-workaround/57029
-if ProcessInfo.processInfo.environment["IS_XCTEST"] != nil ||
-    ProcessInfo.processInfo.environment["IS_ARCHIVE"] != nil {
-    targetPlugins.removeAll()
-}
+// if ProcessInfo.processInfo.environment["IS_XCTEST"] != nil ||
+//     ProcessInfo.processInfo.environment["IS_ARCHIVE"] != nil {
+//     targetPlugins.removeAll()
+// }
+
+// ARCHER work around
+//
+// Removes SwiftLintPlugin when resolving package dependencies to
+// bypass Xcode GUI prompt to enable or disable plugin
+targetPlugins.removeAll()
 
 let package = Package(
     name: "EmbraceIO",

--- a/Sources/EmbraceCore/Capture/Network/URLRequest+Extension.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLRequest+Extension.swift
@@ -11,11 +11,16 @@ extension URLRequest {
     }
 
     func addEmbraceHeaders() -> URLRequest {
-        var mutableRequest = self
-        mutableRequest.setValue(UUID().uuidString,
-                                forHTTPHeaderField: Header.id)
-        mutableRequest.setValue(Date().serializedInterval.description,
-                                forHTTPHeaderField: Header.startTime)
-        return mutableRequest
+        // var mutableRequest = self
+        // mutableRequest.setValue(UUID().uuidString,
+        //                         forHTTPHeaderField: Header.id)
+        // mutableRequest.setValue(Date().serializedInterval.description,
+        //                         forHTTPHeaderField: Header.startTime)
+        // return mutableRequest
+
+        // ARCHER work around
+        //
+        // Do not include Embrace headers `id` and `startTime`
+        self
     }
 }

--- a/Sources/EmbraceCore/Capture/Network/URLSessionCaptureService.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLSessionCaptureService.swift
@@ -69,12 +69,17 @@ public final class URLSessionCaptureService: CaptureService, URLSessionTaskHandl
 
     var injectTracingHeader: Bool {
         // check remote config
-        guard Embrace.client?.config?.isNetworkSpansForwardingEnabled == true else {
-            return false
-        }
+        // guard Embrace.client?.config?.isNetworkSpansForwardingEnabled == true else {
+        //     return false
+        // }
 
         // check local config
-        return options.injectTracingHeader
+        // return options.injectTracingHeader
+
+        // ARCHER work around
+        //
+        // Bypass guard statement and always return tracing header
+        options.injectTracingHeader
     }
 
     var requestsDataSource: URLSessionRequestsDataSource? {

--- a/Sources/EmbraceCore/Capture/Network/URLSessionTaskHandler.swift
+++ b/Sources/EmbraceCore/Capture/Network/URLSessionTaskHandler.swift
@@ -203,6 +203,13 @@ final class DefaultURLSessionTaskHandler: URLSessionTaskHandler {
             return previousValue
         }
 
+        // ARCHER work around
+        //
+        // Inject necessary header keys/values
+        task.injectHeader(withKey: "X-B3-TraceId", value: span.context.traceId.hexString)
+        task.injectHeader(withKey: "X-B3-SpanId", value: span.context.spanId.hexString)
+        task.injectHeader(withKey: "X-B3-Sampled", value: "1")
+
         let value = W3C.traceparent(from: span.context)
         if task.injectHeader(withKey: W3C.traceparentHeaderName, value: value) {
             return value


### PR DESCRIPTION
## Description
<!--- Describe the problem being tackled by this PR -->
We have forked a copy of the Embrace SDK to ArcherGDA to make edits to their codebase. These are necessary for the SDK to function properly within the Archer iOS codebase.

As of this PR, we are going to use a branch off of `main` at commit `f76e05d2c610caa159714a43654f9ecf4e74c2f7`. This should allow us to update `main` in the future while we continue to use a forked copy.

In this PR:
* Remove all usage of the `SwiftLintPlugin`
  * Plugin requires enabling/disabling via a GUI prompt
  * We don't need the plugin and the GUI disrupts building and running the app locally and won't work with CI/CD 
* Update headers
  * Remove Embrace headers
  * Adapt SDK to send B3 and WC3 propagator headers